### PR TITLE
Fixed regex functions

### DIFF
--- a/dsl.go
+++ b/dsl.go
@@ -170,12 +170,12 @@ func HelperFunctions() (functions map[string]govaluate.ExpressionFunction) {
 	}
 
 	functions["regex"] = func(args ...interface{}) (interface{}, error) {
-		compiled, err := Regex(toString(args[0]))
+		compiled, err := Regex(toString(args[1]))
 		if err != nil {
 			return nil, err
 		}
 
-		return compiled.MatchString(toString(args[1])), nil
+		return compiled.MatchString(toString(args[0])), nil
 	}
 
 	functions["regex_all"] = func(args ...interface{}) (interface{}, error) {
@@ -184,7 +184,7 @@ func HelperFunctions() (functions map[string]govaluate.ExpressionFunction) {
 			if err != nil {
 				return nil, err
 			}
-			if !compiled.MatchString(toString(args[1])) {
+			if !compiled.MatchString(toString(args[0])) {
 				return false, nil
 			}
 		}
@@ -197,7 +197,7 @@ func HelperFunctions() (functions map[string]govaluate.ExpressionFunction) {
 			if err != nil {
 				return nil, err
 			}
-			if compiled.MatchString(toString(args[1])) {
+			if compiled.MatchString(toString(args[0])) {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
The regex functions did not work correctly with arguments. As a result, when you tried to write the following DSL expression:

```
regex(request, '\Asomethin\z')
```

the 'request' part was used as a regex expression and '\Asomethin\z' as a string for matching.

The `regex_all` and `regex_any` functions did not use the first argument.