### PR TITLE
refactor: support variadic args for `regex_{all,any}` and `equals_any`

### DIFF
--- a/dsl.go
+++ b/dsl.go
@@ -706,38 +706,67 @@ func init() {
 		}
 		return compiled.MatchString(toString(args[1])), nil
 	}))
-	MustAddFunction(NewWithPositionalArgs("regex_all", 2, true, func(args ...interface{}) (interface{}, error) {
-		for _, arg := range toStringSlice(args[1]) {
-			compiled, err := Regex(toString(arg))
+	MustAddFunction(NewWithSingleSignature("regex_all",
+		"(pattern string, inputs ...string) bool",
+		true,
+		func(args ...interface{}) (interface{}, error) {
+			if len(args) < 2 {
+				return nil, ErrInvalidDslFunction
+			}
+
+			compiled, err := regexp.Compile(toString(args[0]))
 			if err != nil {
 				return nil, err
 			}
-			if !compiled.MatchString(toString(args[0])) {
-				return false, nil
+
+			for _, arg := range args[1:] {
+				if !compiled.MatchString(toString(arg)) {
+					return false, nil
+				}
 			}
-		}
-		return false, nil
-	}))
-	MustAddFunction(NewWithPositionalArgs("regex_any", 2, true, func(args ...interface{}) (interface{}, error) {
-		for _, arg := range toStringSlice(args[1]) {
-			compiled, err := Regex(toString(arg))
+
+			return true, nil
+		}))
+	MustAddFunction(NewWithSingleSignature("regex_any",
+		"(pattern string, inputs ...string) bool",
+		true,
+		func(args ...interface{}) (interface{}, error) {
+			if len(args) < 2 {
+				return nil, ErrInvalidDslFunction
+			}
+
+			pattern := toString(args[0])
+			compiled, err := regexp.Compile(pattern)
 			if err != nil {
 				return nil, err
 			}
-			if compiled.MatchString(toString(args[0])) {
-				return true, nil
+
+			for _, arg := range args[1:] {
+				if compiled.MatchString(toString(arg)) {
+					return true, nil
+				}
 			}
-		}
-		return false, nil
-	}))
-	MustAddFunction(NewWithPositionalArgs("equals_any", 2, true, func(args ...interface{}) (interface{}, error) {
-		for _, arg := range toStringSlice(args[1]) {
-			if args[0] == arg {
-				return true, nil
+
+			return false, nil
+		}))
+	MustAddFunction(NewWithSingleSignature("equals_any",
+		"(s interface{}, subs ...interface{}) bool",
+		true,
+		func(args ...interface{}) (interface{}, error) {
+			if len(args) < 2 {
+				return nil, ErrInvalidDslFunction
 			}
-		}
-		return false, nil
-	}))
+
+			s := toString(args[0])
+
+			for _, arg := range args[1:] {
+				if toString(arg) == s {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		}))
 	MustAddFunction(NewWithPositionalArgs("remove_bad_chars", 2, true, func(args ...interface{}) (interface{}, error) {
 		input := toString(args[0])
 		badChars := toString(args[1])

--- a/engine.go
+++ b/engine.go
@@ -1,17 +1,12 @@
 package dsl
 
 import (
-	"regexp"
 	"sync"
 
 	"github.com/Knetic/govaluate"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
-var (
-	defaultEngine *Engine
-	RegexStore    = &mapsutil.SyncLockMap[string, *regexp.Regexp]{Map: make(mapsutil.Map[string, *regexp.Regexp])}
-)
+var defaultEngine *Engine
 
 type Engine struct {
 	HelperFunctions map[string]govaluate.ExpressionFunction
@@ -59,18 +54,4 @@ func EvalExpr(expr string, vars map[string]interface{}) (interface{}, error) {
 	}
 
 	return defaultEngine.EvalExprFromCache(expr, vars)
-}
-
-func Regex(regxp string) (*regexp.Regexp, error) {
-	if compiled, ok := RegexStore.Get(regxp); ok {
-		return compiled, nil
-	}
-
-	compiled, err := regexp.Compile(regxp)
-	if err != nil {
-		return nil, err
-	}
-	_ = RegexStore.Set(regxp, compiled)
-
-	return compiled, nil
 }

--- a/util.go
+++ b/util.go
@@ -78,24 +78,6 @@ func toString(data interface{}) string {
 	}
 }
 
-func toStringSlice(v interface{}) (m []string) {
-	switch vv := v.(type) {
-	case []string:
-		for _, item := range vv {
-			m = append(m, toString(item))
-		}
-	case []int:
-		for _, item := range vv {
-			m = append(m, toString(item))
-		}
-	case []float64:
-		for _, item := range vv {
-			m = append(m, toString(item))
-		}
-	}
-	return
-}
-
 func insertInto(s string, interval int, sep rune) string {
 	var buffer bytes.Buffer
 	before := interval - 1


### PR DESCRIPTION
Closes #251
Fixes #250 