### PR TITLE
support different-length inputs in xor()

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,10 @@
+[default.extend-words]
+# intentional test data
+comparitive = "comparitive"
+examplify = "examplify"
+
+[default.extend-identifiers]
+TrUe = "TrUe"
+
+[files]
+extend-exclude = ["go.sum"]

--- a/dsl.go
+++ b/dsl.go
@@ -1413,7 +1413,8 @@ func init() {
 				return nil, errors.New("at least two arguments needed")
 			}
 
-			n := -1
+			inputs := make([][]byte, 0, len(args))
+			maxLen := 0
 			for _, arg := range args {
 				var b []byte
 				switch v := arg.(type) {
@@ -1424,21 +1425,19 @@ func init() {
 				default:
 					return nil, fmt.Errorf("invalid argument type %T", arg)
 				}
-				if n == -1 {
-					n = len(b)
-				} else if len(b) != n {
-					return nil, errors.New("all arguments must have the same length")
+				if len(b) == 0 {
+					return nil, errors.New("empty arguments are not allowed")
+				}
+				inputs = append(inputs, b)
+				if len(b) > maxLen {
+					maxLen = len(b)
 				}
 			}
 
-			result := make([]byte, n)
-			for i := 0; i < n; i++ {
-				for _, arg := range args {
-					b, ok := arg.([]byte)
-					if !ok {
-						b = []byte(arg.(string))
-					}
-					result[i] ^= b[i]
+			result := make([]byte, maxLen)
+			for i := 0; i < maxLen; i++ {
+				for _, b := range inputs {
+					result[i] ^= b[i%len(b)]
 				}
 			}
 
@@ -1739,8 +1738,8 @@ func AddMultiSignatureHelperFunction(key string, signatureparts []string, cachea
 	return AddFunction(function)
 }
 
-func GetFunctionNames(heperFunctions map[string]govaluate.ExpressionFunction) []string {
-	return maputils.GetKeys(heperFunctions)
+func GetFunctionNames(helperFunctions map[string]govaluate.ExpressionFunction) []string {
+	return maputils.GetKeys(helperFunctions)
 }
 
 // GetPrintableDslFunctionSignatures returns the function signatures for the

--- a/dsl_test.go
+++ b/dsl_test.go
@@ -462,6 +462,8 @@ func TestDslExpressions(t *testing.T) {
 		`ip_format('127.0.1.0', '11')`:                                                               "127.0.256",
 		"unpack('>I', '\xac\xd7\t\xd0')":                                                             -272646673,
 		"xor('\x01\x02', '\x02\x01')":                                                                []uint8([]byte{0x3, 0x3}),
+		"xor('\x01\x02\x03\x04', '\x02\x01')":                                                        []uint8([]byte{0x3, 0x3, 0x1, 0x5}),
+		"xor('\x05', '\x01\x02\x03')":                                                                 []uint8([]byte{0x4, 0x7, 0x6}),
 		`count("projectdiscovery", "e")`:                                                             2,
 		`concat(to_title("pRoJeCt"), to_title("diScOvErY"))`:                                         "ProjectDiscovery",
 		`concat(to_title("welcome "), "to", to_title(" watch"), to_title("mojo"))`:                   "Welcome to WatchMojo",


### PR DESCRIPTION
Closes #297

- Cycle shorter inputs using modulo indexing instead of rejecting length mismatches
- Backward compatible: same-length inputs behave identically